### PR TITLE
Disable chart animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
         }]
       },
       options: {
+        animation: { duration: 0 },
         scales: {
           y: {
             beginAtZero: true,
@@ -39,7 +40,7 @@
 
     function updateChart(gamesPlayed) {
       chart.data.datasets[0].data = players.map(p => (wins[p] / gamesPlayed * 100).toFixed(1));
-      chart.update();
+      chart.update('none');
     }
 
       async function simulateWins() {


### PR DESCRIPTION
## Summary
- Disable chart.js animation so bars jump instantly
- Update chart without transitions

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d650e00c832ba27dbe840e527fda