### PR TITLE
Hide win% legend and update title

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Win Percentage Chart</title>
+  <title>Win % by Player</title>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
-  <h1>Win Percentage</h1>
+  <h1>Win % by Player</h1>
   <canvas id="winChart" width="400" height="200"></canvas>
 
   <script>
@@ -27,6 +27,9 @@
         }]
       },
       options: {
+        plugins: {
+          legend: { display: false }
+        },
         animation: { duration: 0 },
         scales: {
           y: {


### PR DESCRIPTION
## Summary
- replace page title and heading with "Win % by Player"
- disable Chart.js legend to remove floating "Win %" bar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c74fa9c824832b999d4b917163cb11